### PR TITLE
Add Trace without Turing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,11 @@ version = "0.1.0"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+Libtask = "6f1fad26-d15e-5dc8-ae53-837a1d7b8c9f"
+StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 
 [compat]
 Distributions = "0.23, 0.24"
+Libtask = "0.5"
+StatsFuns = "0.9"
 julia = "1.3"

--- a/src/AdvancedPS.jl
+++ b/src/AdvancedPS.jl
@@ -1,6 +1,10 @@
 module AdvancedPS
 
 import Distributions
+import Libtask
+import StatsFuns
 
 include("resampling.jl")
+include("container.jl")
+
 end

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -16,11 +16,6 @@ function ResampleWithESSThreshold(resampler = resample)
     ResampleWithESSThreshold(resampler, 0.5)
 end
 
-# Default resampling scheme
-function resample(w::AbstractVector{<:Real}, num_particles::Integer=length(w))
-    return resample_systematic(w, num_particles)
-end
-
 # More stable, faster version of rand(Categorical)
 function randcat(p::AbstractVector{<:Real})
     T = eltype(p)
@@ -36,11 +31,17 @@ function randcat(p::AbstractVector{<:Real})
     return s
 end
 
-function resample_multinomial(w::AbstractVector{<:Real}, num_particles::Integer)
+function resample_multinomial(
+    w::AbstractVector{<:Real},
+    num_particles::Integer = length(w),
+)
     return rand(Distributions.sampler(Distributions.Categorical(w)), num_particles)
 end
 
-function resample_residual(w::AbstractVector{<:Real}, num_particles::Integer)
+function resample_residual(
+    w::AbstractVector{<:Real},
+    num_particles::Integer = length(weights),
+)
     # Pre-allocate array for resampled particles
     indices = Vector{Int}(undef, num_particles)
 
@@ -79,7 +80,7 @@ are selected according to the multinomial distribution defined by the normalized
 i.e., `xᵢ = j` if and only if
 ``uᵢ \\in [\\sum_{s=1}^{j-1} weights_{s}, \\sum_{s=1}^{j} weights_{s})``.
 """
-function resample_stratified(weights::AbstractVector{<:Real}, n::Integer)
+function resample_stratified(weights::AbstractVector{<:Real}, n::Integer = length(weights))
     # check input
     m = length(weights)
     m > 0 || error("weight vector is empty")
@@ -124,7 +125,7 @@ numbers `u₁`, ..., `uₙ` where ``uₖ = (u + k − 1) / n``. Based on these n
 normalized `weights`, i.e., `xᵢ = j` if and only if
 ``uᵢ \\in [\\sum_{s=1}^{j-1} weights_{s}, \\sum_{s=1}^{j} weights_{s})``.
 """
-function resample_systematic(weights::AbstractVector{<:Real}, n::Integer)
+function resample_systematic(weights::AbstractVector{<:Real}, n::Integer = length(weights))
     # check input
     m = length(weights)
     m > 0 || error("weight vector is empty")
@@ -157,3 +158,6 @@ function resample_systematic(weights::AbstractVector{<:Real}, n::Integer)
 
     return samples
 end
+
+# Default resampling scheme
+const resample = resample_systematic

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,7 @@
 [deps]
+Libtask = "6f1fad26-d15e-5dc8-ae53-837a1d7b8c9f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+Libtask = "0.5"
 julia = "1.3"

--- a/test/container.jl
+++ b/test/container.jl
@@ -1,25 +1,14 @@
-using Turing, Random
-using Turing: ParticleContainer, getweights, getweight,
-    effectiveSampleSize, Trace, current_trace, VarName, VarInfo,
-    Sampler, consume, produce, fork, getlogp
-using Turing.Core: logZ, reset_logweights!, increase_logweight!,
-    resample_propagate!, reweight!
-using Test
-
-dir = splitdir(splitdir(pathof(Turing))[1])[1]
-include(dir*"/test/test_utils/AllUtils.jl")
-
 @testset "container.jl" begin
-    @turing_testset "copy particle container" begin
-        pc = ParticleContainer(Trace[])
+    @testset "copy particle container" begin
+        pc = AdvancedPS.ParticleContainer(AdvancedPS.Trace[])
         newpc = copy(pc)
 
         @test newpc.logWs == pc.logWs
         @test typeof(pc) === typeof(newpc)
     end
 
-    @turing_testset "particle container" begin
-        # Create a resumable function that always yields `logp`.
+    @testset "particle container" begin
+        # Create a resumable function that always returns the same log probability.
         function fpc(logp)
             f = let logp = logp
                 () -> begin
@@ -31,97 +20,83 @@ include(dir*"/test/test_utils/AllUtils.jl")
             return f
         end
 
-        # Dummy sampler that is not actually used.
-        sampler = Sampler(PG(5), empty_model())
-
         # Create particle container.
         logps = [0.0, -1.0, -2.0]
-        particles = [Trace(fpc(logp), empty_model(), sampler, VarInfo()) for logp in logps]
-        pc = ParticleContainer(particles)
+        particles = [AdvancedPS.Trace(fpc(logp)) for logp in logps]
+        pc = AdvancedPS.ParticleContainer(particles)
 
         # Initial state.
-        @test all(iszero(getlogp(particle.vi)) for particle in pc.vals)
         @test pc.logWs == zeros(3)
-        @test getweights(pc) == fill(1/3, 3)
-        @test all(getweight(pc, i) == 1/3 for i in 1:3)
-        @test logZ(pc) ≈ log(3)
-        @test effectiveSampleSize(pc) == 3
+        @test AdvancedPS.getweights(pc) == fill(1/3, 3)
+        @test all(AdvancedPS.getweight(pc, i) == 1/3 for i in 1:3)
+        @test AdvancedPS.logZ(pc) ≈ log(3)
+        @test AdvancedPS.effectiveSampleSize(pc) == 3
 
         # Reweight particles.
-        reweight!(pc)
-        @test all(iszero(getlogp(particle.vi)) for particle in pc.vals)
+        AdvancedPS.reweight!(pc)
         @test pc.logWs == logps
-        @test getweights(pc) ≈ exp.(logps) ./ sum(exp, logps)
-        @test all(getweight(pc, i) ≈ exp(logps[i]) / sum(exp, logps) for i in 1:3)
-        @test logZ(pc) ≈ log(sum(exp, logps))
+        @test AdvancedPS.getweights(pc) ≈ exp.(logps) ./ sum(exp, logps)
+        @test all(AdvancedPS.getweight(pc, i) ≈ exp(logps[i]) / sum(exp, logps) for i in 1:3)
+        @test AdvancedPS.logZ(pc) ≈ log(sum(exp, logps))
 
         # Reweight particles.
-        reweight!(pc)
-        @test all(iszero(getlogp(particle.vi)) for particle in pc.vals)
+        AdvancedPS.reweight!(pc)
         @test pc.logWs == 2 .* logps
-        @test getweights(pc) == exp.(2 .* logps) ./ sum(exp, 2 .* logps)
-        @test all(getweight(pc, i) ≈ exp(2 * logps[i]) / sum(exp, 2 .* logps) for i in 1:3)
-        @test logZ(pc) ≈ log(sum(exp, 2 .* logps))
+        @test AdvancedPS.getweights(pc) == exp.(2 .* logps) ./ sum(exp, 2 .* logps)
+        @test all(AdvancedPS.getweight(pc, i) ≈ exp(2 * logps[i]) / sum(exp, 2 .* logps) for i in 1:3)
+        @test AdvancedPS.logZ(pc) ≈ log(sum(exp, 2 .* logps))
 
         # Resample and propagate particles.
-        resample_propagate!(pc)
-        @test all(iszero(getlogp(particle.vi)) for particle in pc.vals)
+        AdvancedPS.resample_propagate!(pc)
         @test pc.logWs == zeros(3)
-        @test getweights(pc) == fill(1/3, 3)
-        @test all(getweight(pc, i) == 1/3 for i in 1:3)
-        @test logZ(pc) ≈ log(3)
-        @test effectiveSampleSize(pc) == 3
+        @test AdvancedPS.getweights(pc) == fill(1/3, 3)
+        @test all(AdvancedPS.getweight(pc, i) == 1/3 for i in 1:3)
+        @test AdvancedPS.logZ(pc) ≈ log(3)
+        @test AdvancedPS.effectiveSampleSize(pc) == 3
 
         # Reweight particles.
-        reweight!(pc)
-        @test all(iszero(getlogp(particle.vi)) for particle in pc.vals)
+        AdvancedPS.reweight!(pc)
         @test pc.logWs ⊆ logps
-        @test getweights(pc) == exp.(pc.logWs) ./ sum(exp, pc.logWs)
-        @test all(getweight(pc, i) ≈ exp(pc.logWs[i]) / sum(exp, pc.logWs) for i in 1:3)
-        @test logZ(pc) ≈ log(sum(exp, pc.logWs))
+        @test AdvancedPS.getweights(pc) == exp.(pc.logWs) ./ sum(exp, pc.logWs)
+        @test all(AdvancedPS.getweight(pc, i) ≈ exp(pc.logWs[i]) / sum(exp, pc.logWs) for i in 1:3)
+        @test AdvancedPS.logZ(pc) ≈ log(sum(exp, pc.logWs))
 
         # Increase unnormalized logarithmic weights.
         logws = copy(pc.logWs)
-        increase_logweight!(pc, 2, 1.41)
+        AdvancedPS.increase_logweight!(pc, 2, 1.41)
         @test pc.logWs == logws + [0, 1.41, 0]
 
         # Reset unnormalized logarithmic weights.
         logws = pc.logWs
-        reset_logweights!(pc)
+        AdvancedPS.reset_logweights!(pc)
         @test pc.logWs === logws
         @test all(iszero, pc.logWs)
     end
 
-    @turing_testset "trace" begin
+    @testset "trace" begin
         n = Ref(0)
-
-        alg = PG(5)
-        spl = Sampler(alg, empty_model())
-        dist = Normal(0, 1)
         function f2()
-            t = TArray(Int, 1);
-            t[1] = 0;
+            t = TArray(Int, 1)
+            t[1] = 0
             while true
-                ct = current_trace()
-                vn = @varname x[n]
-                Turing.assume(Random.GLOBAL_RNG, spl, dist, vn, ct.vi)
                 n[] += 1
                 produce(t[1])
-                vn = @varname x[n]
-                Turing.assume(Random.GLOBAL_RNG, spl, dist, vn, ct.vi)
                 n[] += 1
                 t[1] = 1 + t[1]
             end
         end
 
         # Test task copy version of trace
-        tr = Trace(f2, empty_model(), spl, VarInfo())
+        tr = AdvancedPS.Trace(f2)
 
-        consume(tr); consume(tr)
-        a = fork(tr);
-        consume(a); consume(a)
+        consume(tr.ctask)
+        consume(tr.ctask)
 
-        @test consume(tr) == 2
-        @test consume(a) == 4
+        a = AdvancedPS.fork(tr)
+        consume(a.ctask)
+        consume(a.ctask)
+
+        @test consume(tr.ctask) == 2
+        @test consume(a.ctask) == 4
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using AdvancedPS
+using Libtask
 using Test
 
 @testset "AdvancedPS.jl" begin
     @testset "Resampling tests" begin include("resampling.jl") end
+    @testset "Container tests" begin include("container.jl") end
 end


### PR DESCRIPTION
In this PR I removed all Turing-specific parts from Trace. As in the last commits, the intention was to keep otherwise the same implementation, with all its flaws and annoyances, to both reduce the number of changes and to speed up the process of integrating AdvancedPS in Turing. Therefore I also prepared a corresponding PR to Turing that adds AdvancedPS and uses `AdvancedPS.Trace` and the implementation of resampling, propagation and particle sweeps in AdvancedPS.

Since I tried to avoid any significant changes, some of the API might still be too Turing- and Libtask-specific. However, it already allows to use general models that yield the log probabilities of the observations with `Libtask.produce`.