### PR TITLE
SMC and PG algorithms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         version:
           - '1.3'
-          - '1'
+          - '1.5'
           - 'nightly'
         os:
           - ubuntu-latest
@@ -28,7 +28,7 @@ jobs:
           - os: macOS-latest
             arch: x86
         include:
-          - version: '1'
+          - version: '1.5'
             os: ubuntu-latest
             arch: x64
             coverage: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         version:
           - '1.3'
-          - '1.5'
+          - '1'
           - 'nightly'
         os:
           - ubuntu-latest
@@ -28,7 +28,7 @@ jobs:
           - os: macOS-latest
             arch: x86
         include:
-          - version: '1.5'
+          - version: '1'
             os: ubuntu-latest
             arch: x64
             coverage: true

--- a/Project.toml
+++ b/Project.toml
@@ -4,12 +4,14 @@ authors = ["TuringLang"]
 version = "0.2.0"
 
 [deps]
+AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Libtask = "6f1fad26-d15e-5dc8-ae53-837a1d7b8c9f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 
 [compat]
+AbstractMCMC = "2"
 Distributions = "0.23, 0.24"
 Libtask = "0.5"
 StatsFuns = "0.9"

--- a/src/AdvancedPS.jl
+++ b/src/AdvancedPS.jl
@@ -9,5 +9,6 @@ import StatsFuns
 include("resampling.jl")
 include("container.jl")
 include("smc.jl")
+include("model.jl")
 
 end

--- a/src/AdvancedPS.jl
+++ b/src/AdvancedPS.jl
@@ -1,5 +1,6 @@
 module AdvancedPS
 
+import AbstractMCMC
 import Distributions
 import Libtask
 import Random
@@ -7,5 +8,6 @@ import StatsFuns
 
 include("resampling.jl")
 include("container.jl")
+include("smc.jl")
 
 end

--- a/src/model.jl
+++ b/src/model.jl
@@ -1,0 +1,8 @@
+"""
+    observe(dist::Distribution, x)
+
+Observe sample `x` from distribution `dist` and yield its log-likelihood value.
+"""
+function observe(dist::Distributions.Distribution, x)
+    return Libtask.produce(Distributions.loglikelihood(dist, x))
+end

--- a/src/smc.jl
+++ b/src/smc.jl
@@ -5,7 +5,7 @@ end
 
 """
     SMC(n[, resampler = ResampleWithESSThreshold()])
-    SMC(n[, resampler = resample_systematic, ]threshold)
+    SMC(n, [resampler = resample_systematic, ]threshold)
 
 Create a sequential Monte Carlo (SMC) sampler with `n` particles.
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,8 +1,12 @@
 [deps]
+AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Libtask = "6f1fad26-d15e-5dc8-ae53-837a1d7b8c9f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+AbstractMCMC = "2"
+Distributions = "0.24"
 Libtask = "0.5"
 julia = "1.3"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,6 @@
 using AdvancedPS
+using AbstractMCMC
+using Distributions
 using Libtask
 using Random
 using Test
@@ -6,4 +8,5 @@ using Test
 @testset "AdvancedPS.jl" begin
     @testset "Resampling tests" begin include("resampling.jl") end
     @testset "Container tests" begin include("container.jl") end
+    @testset "SMC and PG tests" begin include("smc.jl") end
 end

--- a/test/smc.jl
+++ b/test/smc.jl
@@ -1,179 +1,153 @@
-using Turing, Random, Test
-using Turing.Core: ResampleWithESSThreshold
-using Turing.Inference: getspace, resample_systematic, resample_multinomial
+@testset "smc.jl" begin
+    @testset "SMC constructor" begin
+        sampler = AdvancedPS.SMC(10)
+        @test sampler.nparticles == 10
+        @test sampler.resampler == AdvancedPS.ResampleWithESSThreshold()
 
-using Random
+        sampler = AdvancedPS.SMC(15, 0.6)
+        @test sampler.nparticles == 15
+        @test sampler.resampler ===
+            AdvancedPS.ResampleWithESSThreshold(AdvancedPS.resample_systematic, 0.6)
 
-dir = splitdir(splitdir(pathof(Turing))[1])[1]
-include(dir*"/test/test_utils/AllUtils.jl")
+        sampler = AdvancedPS.SMC(20, AdvancedPS.resample_multinomial, 0.6)
+        @test sampler.nparticles == 20
+        @test sampler.resampler ===
+            AdvancedPS.ResampleWithESSThreshold(AdvancedPS.resample_multinomial, 0.6)
 
-@testset "SMC" begin
-    @turing_testset "constructor" begin
-        s = SMC()
-        @test s.resampler == ResampleWithESSThreshold()
-        @test getspace(s) === ()
-
-        s = SMC(:x)
-        @test s.resampler == ResampleWithESSThreshold()
-        @test getspace(s) === (:x,)
-
-        s = SMC((:x,))
-        @test s.resampler == ResampleWithESSThreshold()
-        @test getspace(s) === (:x,)
-
-        s = SMC(:x, :y)
-        @test s.resampler == ResampleWithESSThreshold()
-        @test getspace(s) === (:x, :y)
-
-        s = SMC((:x, :y))
-        @test s.resampler == ResampleWithESSThreshold()
-        @test getspace(s) === (:x, :y)
-
-        s = SMC(0.6)
-        @test s.resampler === ResampleWithESSThreshold(resample_systematic, 0.6)
-        @test getspace(s) === ()
-
-        s = SMC(0.6, (:x,))
-        @test s.resampler === ResampleWithESSThreshold(resample_systematic, 0.6)
-        @test getspace(s) === (:x,)
-
-        s = SMC(resample_multinomial, 0.6)
-        @test s.resampler === ResampleWithESSThreshold(resample_multinomial, 0.6)
-        @test getspace(s) === ()
-
-        s = SMC(resample_multinomial, 0.6, (:x,))
-        @test s.resampler === ResampleWithESSThreshold(resample_multinomial, 0.6)
-        @test getspace(s) === (:x,)
-
-        s = SMC(resample_systematic)
-        @test s.resampler === resample_systematic
-        @test getspace(s) === ()
-
-        s = SMC(resample_systematic, (:x,))
-        @test s.resampler === resample_systematic
-        @test getspace(s) === (:x,)
+        sampler = AdvancedPS.SMC(25, AdvancedPS.resample_systematic)
+        @test sampler.nparticles == 25
+        @test sampler.resampler === AdvancedPS.resample_systematic
     end
 
-    @turing_testset "models" begin
-        @model function normal()
-            a ~ Normal(4,5)
-            3 ~ Normal(a,2)
-            b ~ Normal(a,1)
-            1.5 ~ Normal(b,2)
-            a, b
+    # Smoke tests
+    @testset "models" begin
+        mutable struct NormalModel <: AbstractMCMC.AbstractModel
+            a::Float64
+            b::Float64
+
+            NormalModel() = new()
         end
 
-        tested = sample(normal(), SMC(), 100);
+        function (m::NormalModel)()
+            # First latent variable.
+            m.a = a = rand(Normal(4, 5))
+
+            # First observation.
+            produce(logpdf(Normal(a, 2), 3))
+
+            # Second latent variable.
+            m.b = b = rand(Normal(a, 1))
+
+            # Second observation.
+            produce(logpdf(Normal(b, 2), 1.5))
+        end
+        sample(NormalModel(), AdvancedPS.SMC(100))
 
         # failing test
-        @model function fail_smc()
-            a ~ Normal(4,5)
-            3 ~ Normal(a,2)
-            b ~ Normal(a,1)
-            if a >= 4.0
-                1.5 ~ Normal(b,2)
-            end
-            a, b
+        mutable struct FailSMCModel <: AbstractMCMC.AbstractModel
+            a::Float64
+            b::Float64
+
+            FailSMCModel() = new()
         end
 
-        @test_throws ErrorException sample(fail_smc(), SMC(), 100)
+        function (m::FailSMCModel)()
+            m.a = a = rand(Normal(4, 5))
+            m.b = b = rand(Normal(a, 1))
+            if a >= 4
+                produce(logpdf(Normal(b, 2), 1.5))
+            end
+        end
+
+        @test_throws ErrorException sample(FailSMCModel(), AdvancedPS.SMC(100))
     end
 
-    @turing_testset "logevidence" begin
+    @testset "logevidence" begin
         Random.seed!(100)
 
-        @model function test()
-            a ~ Normal(0, 1)
-            x ~ Bernoulli(1)
-            b ~ Gamma(2, 3)
-            1 ~ Bernoulli(x / 2)
-            c ~ Beta()
-            0 ~ Bernoulli(x / 2)
-            x
+        mutable struct TestModel <: AbstractMCMC.AbstractModel
+            a::Float64
+            x::Bool
+            b::Float64
+            c::Float64
+
+            TestModel() = new()
         end
 
-        chains_smc = sample(test(), SMC(), 100)
+        function (m::TestModel)()
+            # First hidden variables.
+            m.a = rand(Normal(0, 1))
+            m.x = x = rand(Bernoulli(1))
+            m.b = rand(Gamma(2, 3))
 
-        @test all(isone, chains_smc[:x])
+            # First observation.
+            produce(logpdf(Bernoulli(x / 2), 1))
+
+            # Second hidden variable.
+            m.c = rand(Beta())
+
+            # Second observation.
+            produce(logpdf(Bernoulli(x / 2), 0))
+        end
+
+        chains_smc = sample(TestModel(), AdvancedPS.SMC(100))
+
+        @test all(isone(p.f.x) for p in chains_smc.trajectories)
         @test chains_smc.logevidence ≈ -2 * log(2)
     end
-end
 
-@testset "PG" begin
-    @turing_testset "constructor" begin
-        s = PG(10)
-        @test s.nparticles == 10
-        @test s.resampler == ResampleWithESSThreshold()
-        @test getspace(s) === ()
+    @testset "PG constructor" begin
+        sampler = AdvancedPS.PG(10)
+        @test sampler.nparticles == 10
+        @test sampler.resampler == AdvancedPS.ResampleWithESSThreshold()
 
-        s = PG(20, :x)
-        @test s.nparticles == 20
-        @test s.resampler == ResampleWithESSThreshold()
-        @test getspace(s) === (:x,)
+        sampler = AdvancedPS.PG(60, 0.6)
+        @test sampler.nparticles == 60
+        @test sampler.resampler ===
+            AdvancedPS.ResampleWithESSThreshold(AdvancedPS.resample_systematic, 0.6)
 
-        s = PG(30, (:x,))
-        @test s.nparticles == 30
-        @test s.resampler == ResampleWithESSThreshold()
-        @test getspace(s) === (:x,)
+        sampler = AdvancedPS.PG(80, AdvancedPS.resample_multinomial, 0.6)
+        @test sampler.nparticles == 80
+        @test sampler.resampler ===
+            AdvancedPS.ResampleWithESSThreshold(AdvancedPS.resample_multinomial, 0.6)
 
-        s = PG(40, :x, :y)
-        @test s.nparticles == 40
-        @test s.resampler == ResampleWithESSThreshold()
-        @test getspace(s) === (:x, :y)
-
-        s = PG(50, (:x, :y))
-        @test s.nparticles == 50
-        @test s.resampler == ResampleWithESSThreshold()
-        @test getspace(s) === (:x, :y)
-
-        s = PG(60, 0.6)
-        @test s.nparticles == 60
-        @test s.resampler === ResampleWithESSThreshold(resample_systematic, 0.6)
-        @test getspace(s) === ()
-
-        s = PG(70, 0.6, (:x,))
-        @test s.nparticles == 70
-        @test s.resampler === ResampleWithESSThreshold(resample_systematic, 0.6)
-        @test getspace(s) === (:x,)
-
-        s = PG(80, resample_multinomial, 0.6)
-        @test s.nparticles == 80
-        @test s.resampler === ResampleWithESSThreshold(resample_multinomial, 0.6)
-        @test getspace(s) === ()
-
-        s = PG(90, resample_multinomial, 0.6, (:x,))
-        @test s.nparticles == 90
-        @test s.resampler === ResampleWithESSThreshold(resample_multinomial, 0.6)
-        @test getspace(s) === (:x,)
-
-        s = PG(100, resample_systematic)
-        @test s.nparticles == 100
-        @test s.resampler === resample_systematic
-        @test getspace(s) === ()
-
-        s = PG(110, resample_systematic, (:x,))
-        @test s.nparticles == 110
-        @test s.resampler === resample_systematic
-        @test getspace(s) === (:x,)
+        sampler = AdvancedPS.PG(100, AdvancedPS.resample_systematic)
+        @test sampler.nparticles == 100
+        @test sampler.resampler === AdvancedPS.resample_systematic
     end
 
-    @turing_testset "logevidence" begin
+    @testset "logevidence" begin
         Random.seed!(100)
 
-        @model function test()
-            a ~ Normal(0, 1)
-            x ~ Bernoulli(1)
-            b ~ Gamma(2, 3)
-            1 ~ Bernoulli(x / 2)
-            c ~ Beta()
-            0 ~ Bernoulli(x / 2)
-            x
+        mutable struct TestModel <: AbstractMCMC.AbstractModel
+            a::Float64
+            x::Bool
+            b::Float64
+            c::Float64
+
+            TestModel() = new()
         end
 
-        chains_pg = sample(test(), PG(10), 100)
+        function (m::TestModel)()
+            # First hidden variables.
+            m.a = rand(Normal(0, 1))
+            m.x = x = rand(Bernoulli(1))
+            m.b = rand(Gamma(2, 3))
 
-        @test all(isone, chains_pg[:x])
-        @test chains_pg.logevidence ≈ -2 * log(2) atol = 0.01
+            # First observation.
+            produce(logpdf(Bernoulli(x / 2), 1))
+
+            # Second hidden variable.
+            m.c = rand(Beta())
+
+            # Second observation.
+            produce(logpdf(Bernoulli(x / 2), 0))
+        end
+
+        chains_pg = sample(TestModel(), AdvancedPS.PG(10), 100)
+
+        @test all(isone(p.trajectory.f.x) for p in chains_pg)
+        @test mean(x.logevidence for x in chains_pg) ≈ -2 * log(2) atol = 0.01
     end
 end
 

--- a/test/smc.jl
+++ b/test/smc.jl
@@ -33,13 +33,13 @@
             m.a = a = rand(Normal(4, 5))
 
             # First observation.
-            produce(logpdf(Normal(a, 2), 3))
+            AdvancedPS.observe(Normal(a, 2), 3)
 
             # Second latent variable.
             m.b = b = rand(Normal(a, 1))
 
             # Second observation.
-            produce(logpdf(Normal(b, 2), 1.5))
+            AdvancedPS.observe(Normal(b, 2), 1.5)
         end
         sample(NormalModel(), AdvancedPS.SMC(100))
 
@@ -55,7 +55,7 @@
             m.a = a = rand(Normal(4, 5))
             m.b = b = rand(Normal(a, 1))
             if a >= 4
-                produce(logpdf(Normal(b, 2), 1.5))
+                AdvancedPS.observe(Normal(b, 2), 1.5)
             end
         end
 
@@ -81,13 +81,13 @@
             m.b = rand(Gamma(2, 3))
 
             # First observation.
-            produce(logpdf(Bernoulli(x / 2), 1))
+            AdvancedPS.observe(Bernoulli(x / 2), 1)
 
             # Second hidden variable.
             m.c = rand(Beta())
 
             # Second observation.
-            produce(logpdf(Bernoulli(x / 2), 0))
+            AdvancedPS.observe(Bernoulli(x / 2), 0)
         end
 
         chains_smc = sample(TestModel(), AdvancedPS.SMC(100))
@@ -135,13 +135,13 @@
             m.b = rand(Gamma(2, 3))
 
             # First observation.
-            produce(logpdf(Bernoulli(x / 2), 1))
+            AdvancedPS.observe(Bernoulli(x / 2), 1)
 
             # Second hidden variable.
             m.c = rand(Beta())
 
             # Second observation.
-            produce(logpdf(Bernoulli(x / 2), 0))
+            AdvancedPS.observe(Bernoulli(x / 2), 0)
         end
 
         chains_pg = sample(TestModel(), AdvancedPS.PG(10), 100)


### PR DESCRIPTION
This removes Turing-specific parts from the SMC and PG algorithms. The (quite limited) tests copied from Turing pass with a callable model but honestly there might very well be some problems with how these rudimentary models and algorithms handle samples and how they are reset.

Some things I noticed:
- One of the main problems/question is how to return samples/trajectories and if/how to provide a special model structure (so far one has to implement a custom model)
- As mentioned before, currently models (also in Turing) only use the global RNG. This is problematic for parallel sampling or just whenever someone passes a custom RNG to `sample`, hence it might be good to instead implement models as `function model(rng::AbstractRNG) ... end` and to make the RNG explicit in `Trace`. I assume that any in general it would be easier to replay trajectories if particles/traces would save the unmutated RNG with which the model was called.