### PR TITLE
Seed particles from top-level RNG

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 [compat]
 AbstractMCMC = "2, 3"
 Distributions = "0.23, 0.24, 0.25"
-Libtask = "0.6"
+Libtask = "0.6.7"
 Random123 = "1.3"
 StatsFuns = "0.9"
 julia = "1.3"

--- a/src/container.jl
+++ b/src/container.jl
@@ -215,12 +215,13 @@ function seed_from_rng!(
 ) where {T,R,N,I}
     n = length(pc.vals)
     nseeds = isnothing(ref) ? n : n - 1
-    rngs = vcat([pc[i].rng for i in 1:nseeds], [pc.rng])
 
     sampler = Random.Sampler(rng, I)
-    for subrng in rngs
+    for i in 1:nseeds
+        subrng = pc.vals[i].rng
         Random.seed!(subrng, gen_seed(rng, subrng, sampler))
     end
+    Random.seed!(pc.rng, gen_seed(rng, pc.rng, sampler))
 
     return pc
 end

--- a/src/container.jl
+++ b/src/container.jl
@@ -209,6 +209,29 @@ function update_keys!(pc::ParticleContainer, ref::Union{Particle,Nothing}=nothin
 end
 
 """
+    seed_from_rng!(pc::ParticleContainer, rng::Random.AbstractRNG, ref::Union{Particle,Nothing}=nothing)
+
+Set seeds of particle rng from user-provided `rng`
+"""
+function seed_from_rng!(
+    pc::ParticleContainer, rng::Random.AbstractRNG, ref::Union{Particle,Nothing}=nothing
+)
+    n = length(pc.vals)
+    isref = isnothing(ref)
+
+    nseeds = isref ? n + 1 : n
+    seeds = gen_seeds(eltype(pc.vals[1].rng.keys), rng, nseeds)
+
+    for i in 1:(nseeds - 1)
+        part = pc.vals[i]
+        Random.seed!(part.rng, seeds[i])
+    end
+
+    Random.seed!(pc.rng, seeds[end])
+    return pc
+end
+
+"""
     resample_propagate!(rng, pc::ParticleContainer[, randcat = resample_systematic,
                         ref = nothing; weights = getweights(pc)])
 

--- a/src/rng.jl
+++ b/src/rng.jl
@@ -50,13 +50,22 @@ function load_state!(rng::TracedRNG)
 end
 
 """
-    update_rng!(rng::TracedRNG)
+    Random.seed!(rng::TracedRNG, key)
 
 Set key and counter of inner rng in `rng` to `key` and the running model step to 0
 """
 function Random.seed!(rng::TracedRNG, key)
     Random.seed!(rng.rng, key)
     return Random123.set_counter!(rng.rng, 0)
+end
+
+"""
+    gen_seeds(trng::TracedRNG, other::Random.AbstractRNG)
+
+Seed a TracedRNG from another 
+"""
+function gen_seeds(::Type{T}, other::Random.AbstractRNG, n::Integer=1) where {T}
+    return Tuple(rand(other, T, n))
 end
 
 """ 

--- a/src/rng.jl
+++ b/src/rng.jl
@@ -1,12 +1,12 @@
 # Default RNG type for when nothing is specified
-const _BASE_RNG = Random123.Philox2x
+const _BASE_RNG = Random123.Philox2x # Rng with state bigger than 1 are broken because of Split
 
 """
     TracedRNG{R,N,T}
 
 Wrapped random number generator from Random123 to keep track of random streams during model evaluation
 """
-mutable struct TracedRNG{R,N,T<:Random123.AbstractR123{R}} <: Random.AbstractRNG
+mutable struct TracedRNG{R,N,T<:Random123.AbstractR123} <: Random.AbstractRNG
     "Model step counter"
     count::Int
     "Inner RNG"
@@ -21,7 +21,7 @@ Create a `TracedRNG` with `r` as the inner RNG.
 """
 function TracedRNG(r::Random123.AbstractR123=_BASE_RNG())
     Random123.set_counter!(r, 0)
-    return TracedRNG(1, r, typeof(r.key)[])
+    return TracedRNG(1, r, Random123.seed_type(r)[])
 end
 
 # Connect to the Random API
@@ -60,12 +60,18 @@ function Random.seed!(rng::TracedRNG, key)
 end
 
 """
-    gen_seeds(trng::TracedRNG, other::Random.AbstractRNG)
+    gen_seed(rng::Random.AbstractRNG, subrng::TracedRNG, sampler::Random.Sampler)
 
-Seed a TracedRNG from another 
+Generate a `seed` for the subrng based on top-level `rng` and `sampler`
 """
-function gen_seeds(::Type{T}, other::Random.AbstractRNG, n::Integer=1) where {T}
-    return Tuple(rand(other, T, n))
+function gen_seed(rng::Random.AbstractRNG, ::TracedRNG{<:Integer}, sampler::Random.Sampler)
+    return rand(rng, sampler)
+end
+
+function gen_seed(
+    rng::Random.AbstractRNG, ::TracedRNG{<:NTuple{N}}, sampler::Random.Sampler
+) where {N}
+    return Tuple(rand(rng, sampler, N))
 end
 
 """ 
@@ -74,8 +80,11 @@ end
 Add current key of the inner rng in `r` to `keys`.
 """
 function save_state!(r::TracedRNG)
-    return push!(r.keys, r.rng.key)
+    return push!(r.keys, state(r.rng))
 end
+
+state(rng::Random123.Philox2x) = rng.key
+state(rng::Random123.Philox4x) = (rng.key1, rng.key2)
 
 Base.copy(r::TracedRNG) = TracedRNG(r.count, copy(r.rng), deepcopy(r.keys))
 

--- a/src/smc.jl
+++ b/src/smc.jl
@@ -39,9 +39,8 @@ function AbstractMCMC.sample(
 
     # Create a set of particles.
     particles = ParticleContainer(
-        [Trace(model, TracedRNG()) for _ in 1:(sampler.nparticles)], TracedRNG()
+        [Trace(model, TracedRNG()) for _ in 1:(sampler.nparticles)], TracedRNG(), rng
     )
-    seed_from_rng!(particles, rng)
 
     # Perform particle sweep.
     logevidence = sweep!(rng, particles, sampler.resampler)
@@ -87,9 +86,8 @@ function AbstractMCMC.step(
 )
     # Create a new set of particles.
     particles = ParticleContainer(
-        [Trace(model, TracedRNG()) for _ in 1:(sampler.nparticles)], TracedRNG()
+        [Trace(model, TracedRNG()) for _ in 1:(sampler.nparticles)], TracedRNG(), rng
     )
-    seed_from_rng!(particles, rng)
 
     # Perform a particle sweep.
     logevidence = sweep!(rng, particles, sampler.resampler)
@@ -120,8 +118,7 @@ function AbstractMCMC.step(
     end
 
     reference = x[end]
-    particles = ParticleContainer(x, TracedRNG())
-    seed_from_rng!(particles, rng, reference)
+    particles = ParticleContainer(x, TracedRNG(), rng)
 
     # Perform a particle sweep.
     logevidence = sweep!(rng, particles, sampler.resampler, reference)

--- a/src/smc.jl
+++ b/src/smc.jl
@@ -41,6 +41,7 @@ function AbstractMCMC.sample(
     particles = ParticleContainer(
         [Trace(model, TracedRNG()) for _ in 1:(sampler.nparticles)], TracedRNG()
     )
+    seed_from_rng!(particles, rng)
 
     # Perform particle sweep.
     logevidence = sweep!(rng, particles, sampler.resampler)
@@ -88,6 +89,7 @@ function AbstractMCMC.step(
     particles = ParticleContainer(
         [Trace(model, TracedRNG()) for _ in 1:(sampler.nparticles)], TracedRNG()
     )
+    seed_from_rng!(particles, rng)
 
     # Perform a particle sweep.
     logevidence = sweep!(rng, particles, sampler.resampler)
@@ -107,6 +109,7 @@ function AbstractMCMC.step(
 )
     # Create a new set of particles.
     nparticles = sampler.nparticles
+
     x = map(1:nparticles) do i
         if i == nparticles
             # Create reference trajectory.
@@ -115,10 +118,13 @@ function AbstractMCMC.step(
             Trace(model, TracedRNG())
         end
     end
+
+    reference = x[end]
     particles = ParticleContainer(x, TracedRNG())
+    seed_from_rng!(particles, rng, reference)
 
     # Perform a particle sweep.
-    logevidence = sweep!(rng, particles, sampler.resampler, particles.vals[nparticles])
+    logevidence = sweep!(rng, particles, sampler.resampler, reference)
 
     # Pick a particle to be retained.
     newtrajectory = rand(rng, particles)

--- a/test/smc.jl
+++ b/test/smc.jl
@@ -7,12 +7,12 @@
         sampler = AdvancedPS.SMC(15, 0.6)
         @test sampler.nparticles == 15
         @test sampler.resampler ===
-              AdvancedPS.ResampleWithESSThreshold(AdvancedPS.resample_systematic, 0.6)
+            AdvancedPS.ResampleWithESSThreshold(AdvancedPS.resample_systematic, 0.6)
 
         sampler = AdvancedPS.SMC(20, AdvancedPS.resample_multinomial, 0.6)
         @test sampler.nparticles == 20
         @test sampler.resampler ===
-              AdvancedPS.ResampleWithESSThreshold(AdvancedPS.resample_multinomial, 0.6)
+            AdvancedPS.ResampleWithESSThreshold(AdvancedPS.resample_multinomial, 0.6)
 
         sampler = AdvancedPS.SMC(25, AdvancedPS.resample_systematic)
         @test sampler.nparticles == 25
@@ -105,12 +105,12 @@
         sampler = AdvancedPS.PG(60, 0.6)
         @test sampler.nparticles == 60
         @test sampler.resampler ===
-              AdvancedPS.ResampleWithESSThreshold(AdvancedPS.resample_systematic, 0.6)
+            AdvancedPS.ResampleWithESSThreshold(AdvancedPS.resample_systematic, 0.6)
 
         sampler = AdvancedPS.PG(80, AdvancedPS.resample_multinomial, 0.6)
         @test sampler.nparticles == 80
         @test sampler.resampler ===
-              AdvancedPS.ResampleWithESSThreshold(AdvancedPS.resample_multinomial, 0.6)
+            AdvancedPS.ResampleWithESSThreshold(AdvancedPS.resample_multinomial, 0.6)
 
         sampler = AdvancedPS.PG(100, AdvancedPS.resample_systematic)
         @test sampler.nparticles == 100


### PR DESCRIPTION
With the new model definition, we should be able to seed the particle inner RNG and reproduce the random streams from the RNG provided in `sample`. Currently something like this would produce two different experiments:

```julia
seed = 100

rng = Random.MersenneTwister(seed)
pg = AdvancedPS.PG(3)
model = Model()

chains = sample(rng, model, pg, 2);

Random.seed!(rng, seed)
# Produces different values
chains = sample(rng, model, pg, 2);
```