### PR TITLE
Update Libtask API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AdvancedPS"
 uuid = "576499cb-2369-40b2-a588-c64705576edc"
 authors = ["TuringLang"]
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/model.jl
+++ b/src/model.jl
@@ -6,10 +6,3 @@ Observe sample `x` from distribution `dist` and yield its log-likelihood value.
 function observe(dist::Distributions.Distribution, x)
     return Libtask.produce(Distributions.loglikelihood(dist, x))
 end
-
-function (instr::Libtask.Instruction{typeof(observe)})()
-    dist = Libtask.val(instr.input[1])
-    x = Libtask.val(instr.input[2])
-    result = Distributions.loglikelihood(dist, x)
-    return Libtask.internal_produce(instr, result)
-end


### PR DESCRIPTION
Customised `Libtask.Instruction{observe}`  is no longer required after https://github.com/TuringLang/Libtask.jl/pull/102