### PR TITLE
Update GenericModel for Turing evaluator

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AdvancedPS"
 uuid = "576499cb-2369-40b2-a588-c64705576edc"
 authors = ["TuringLang"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/model.jl
+++ b/src/model.jl
@@ -59,8 +59,6 @@ end
 # Task copying version of fork for Trace.
 function fork(trace::GenericTrace, isref::Bool=false)
     newtrace = copy(trace)
-    #rng, = newtrace.model.ctask.args
-    #newtrace.rng = rng
     update_rng!(newtrace)
     isref && delete_retained!(newtrace.model.f)
     isref && delete_seeds!(newtrace)


### PR DESCRIPTION
Turing `evaluator` logic does not fit with the `GenericModel{F}` definition. We need something like `GenericModel{F1,F2}` for the `evaluator` and the `model` itself