### PR TITLE
Fix copy mechanism

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AdvancedPS"
 uuid = "576499cb-2369-40b2-a588-c64705576edc"
 authors = ["TuringLang"]
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/examples/gaussian-process/script.jl
+++ b/examples/gaussian-process/script.jl
@@ -54,8 +54,6 @@ function gp_update(model::GPSSM, state, step)
     return Normal(μ[1], σ[1])
 end
 
-Libtask.tape_copy(model::GPSSM) = deepcopy(model)
-
 AdvancedPS.initialization(::GPSSM) = h(model)
 AdvancedPS.transition(model::GPSSM, state, step) = gp_update(model, state, step)
 AdvancedPS.observation(model::GPSSM, state, step) = logpdf(g(model, state, step), y[step])

--- a/examples/particle-gibbs/script.jl
+++ b/examples/particle-gibbs/script.jl
@@ -33,9 +33,9 @@ Parameters = @NamedTuple begin
 end
 
 mutable struct NonLinearTimeSeries <: AbstractMCMC.AbstractModel
-    X::TArray
+    X::Array
     θ::Parameters
-    NonLinearTimeSeries(θ::Parameters) = new(TArray(Float64, θ.T), θ)
+    NonLinearTimeSeries(θ::Parameters) = new(zeros(Float64, θ.T), θ)
 end
 
 f(model::NonLinearTimeSeries, state, t) = Normal(model.θ.a * state, model.θ.q)
@@ -86,10 +86,6 @@ function (model::NonLinearTimeSeries)(rng::Random.AbstractRNG)
         Libtask.produce(score)
     end
 end
-
-# `AdvancedPS` relies on `Libtask` to copy models during their execution but we need to make sure the 
-# internal data of each model is properly copied over as well.
-Libtask.tape_copy(model::NonLinearTimeSeries) = deepcopy(model)
 
 # Here we use the particle gibbs kernel without adaptive resampling.
 model = NonLinearTimeSeries(θ₀)

--- a/test/container.jl
+++ b/test/container.jl
@@ -190,6 +190,6 @@
 
         AdvancedPS.advance!(ref)
         child = AdvancedPS.fork(ref, true)
-        @test length(new_tr.rng.keys) == 1
+        @test length(child.rng.keys) == 1
     end
 end

--- a/test/pgas.jl
+++ b/test/pgas.jl
@@ -79,7 +79,6 @@
 
     @testset "rng stability" begin
         model = BaseModel(Params(0.9, 0.32, 1))
-
         seed = 10
         rng = Random.MersenneTwister(seed)
 


### PR DESCRIPTION
We also need to add the model type to the `deepcopy_types` set to match the previous `tape_copy` mechanism. That should fix documentation building as well