### PR TITLE
Visualize latent state alongside observations

### DIFF
--- a/examples/gaussian-ssm/script.jl
+++ b/examples/gaussian-ssm/script.jl
@@ -84,9 +84,7 @@ end
 
 # Here are the latent and obseravation timeseries
 plot(x; label="x", xlabel="t")
-
-# 
-plot(y; label="y", xlabel="t")
+plot!(y; seriestype=:scatter,label="y", xlabel="t",mc=:red, ms=2, ma=0.5)
 
 # `AdvancedPS` subscribes to the `AbstractMCMC` API. To sample we just need to define a Particle Gibbs kernel
 # and a model interface. 


### PR DESCRIPTION
Visualization improvement: For the linear Gaussian state space model, plot the simulated latent state and the simulated observations atop one another. 

<img width="603" alt="image" src="https://user-images.githubusercontent.com/66295239/225954979-6c85255b-0093-46bf-af04-c4c776fbdcd9.png">

VERSUS

<img width="854" alt="image" src="https://user-images.githubusercontent.com/66295239/225955100-9542bee3-b271-4630-b7d4-cb4f6fe4b60c.png">
