### PR TITLE
Fixed 

### DIFF
--- a/examples/particle-gibbs/script.jl
+++ b/examples/particle-gibbs/script.jl
@@ -1,3 +1,4 @@
+# # Particle Gibbs for non-linear models
 using AdvancedPS
 using Random
 using Distributions
@@ -145,10 +146,13 @@ end
 AdvancedPS.isdone(::NonLinearTimeSeries, step) = step > Tₘ
 
 # We can now sample from the model using the PGAS sampler and collect the trajectories.
-pg = AdvancedPS.PGAS(Nₚ)
-chains = sample(model, pg, Nₛ);
-particles = hcat([trajectory.model.f.X for trajectory in trajectories]...)
-mean_trajectory = mean(particles; dims=2)
+pgas = AdvancedPS.PGAS(Nₚ)
+chains = sample(rng, model, pgas, Nₛ; progress=false);
+trajectories = map(chains) do sample
+    replay(sample.trajectory)
+end
+particles = hcat([trajectory.model.f.X for trajectory in trajectories]...);
+mean_trajectory = mean(particles; dims=2);
 
 # The ancestor sampling has helped with the degeneracy problem and we now have a much more diverse set of trajectories, also at earlier time periods.
 scatter(particles; label=false, opacity=0.01, color=:black, xlabel="t", ylabel="state")


### PR DESCRIPTION
The changes in PR #79 led to the following bugs (some edits in #79 following the review strangely got lost in the final version):

- The title got removed from the example doc
- Long printout of not important vector
- The replay of the trajectories somehow got killed in edits following the PR preview which led the pgas trajectories not showing in the plot.
- The rng argument that was requested to be added to the pgas call also got wiped out in the edits from the review.

This PR fixes all four issues.