### PR TITLE
Update the `update_ref!` API

### DIFF
--- a/ext/AdvancedPSLibtaskExt.jl
+++ b/ext/AdvancedPSLibtaskExt.jl
@@ -146,7 +146,7 @@ function AbstractMCMC.step(
 
     # Perform a particle sweep.
     reference = isref ? particles.vals[nparticles] : nothing
-    logevidence = AdvancedPS.sweep!(rng, particles, sampler.resampler, reference)
+    logevidence = AdvancedPS.sweep!(rng, particles, sampler.resampler, sampler, reference)
 
     # Pick a particle to be retained.
     newtrajectory = rand(rng, particles)
@@ -184,7 +184,7 @@ function AbstractMCMC.sample(
     particles = AdvancedPS.ParticleContainer(traces, AdvancedPS.TracedRNG(), rng)
 
     # Perform particle sweep.
-    logevidence = AdvancedPS.sweep!(rng, particles, sampler.resampler)
+    logevidence = AdvancedPS.sweep!(rng, particles, sampler.resampler, sampler)
 
     replayed = map(particle -> AdvancedPS.replay(particle).model.f, particles.vals)
 

--- a/src/AdvancedPS.jl
+++ b/src/AdvancedPS.jl
@@ -17,8 +17,8 @@ include("resampling.jl")
 include("rng.jl")
 include("model.jl")
 include("container.jl")
-include("pgas.jl")
 include("smc.jl")
+include("pgas.jl")
 
 if !isdefined(Base, :get_extension)
     using Requires

--- a/src/pgas.jl
+++ b/src/pgas.jl
@@ -133,7 +133,7 @@ function forkr(particle::SSMTrace)
     return newtrace
 end
 
-function update_ref!(ref::SSMTrace, pc::ParticleContainer{<:SSMTrace})
+function update_ref!(ref::SSMTrace, pc::ParticleContainer{<:SSMTrace}, sampler::PGAS)
     current_step(ref) <= 2 && return nothing # At the beginning of step + 1 since we start at 1
     isdone(ref.model, current_step(ref)) && return nothing
 

--- a/src/smc.jl
+++ b/src/smc.jl
@@ -46,7 +46,7 @@ function AbstractMCMC.sample(
     particles = ParticleContainer(traces, TracedRNG(), rng)
 
     # Perform particle sweep.
-    logevidence = sweep!(rng, particles, sampler.resampler)
+    logevidence = sweep!(rng, particles, sampler.resampler, sampler)
 
     return SMCSample(collect(particles), getweights(particles), logevidence)
 end
@@ -96,7 +96,7 @@ PGAS(nparticles::Int) = PGAS(nparticles, ResampleWithESSThreshold(1.0))
 function AbstractMCMC.step(
     rng::Random.AbstractRNG,
     model::AbstractStateSpaceModel,
-    sampler::PGAS,
+    sampler::Union{PGAS,PG},
     state::Union{PGState,Nothing}=nothing;
     kwargs...,
 )
@@ -116,7 +116,7 @@ function AbstractMCMC.step(
 
     # Perform a particle sweep.
     reference = isref ? particles.vals[nparticles] : nothing
-    logevidence = sweep!(rng, particles, sampler.resampler, reference)
+    logevidence = sweep!(rng, particles, sampler.resampler, sampler, reference)
 
     # Pick a particle to be retained.
     newtrajectory = rand(particles.rng, particles)

--- a/test/container.jl
+++ b/test/container.jl
@@ -73,8 +73,9 @@
         ref = AdvancedPS.forkr(selected)
         pc_ref.vals[end] = ref
 
+        sampler = AdvancedPS.PG(length(logps))
         AdvancedPS.resample_propagate!(
-            Random.GLOBAL_RNG, pc_ref, AdvancedPS.resample_systematic, ref
+            Random.GLOBAL_RNG, pc_ref, sampler, AdvancedPS.resample_systematic, ref
         )
         @test pc_ref.logWs == zeros(3)
         @test AdvancedPS.getweights(pc_ref) == fill(1 / 3, 3)
@@ -84,7 +85,7 @@
         @test pc_ref.vals[end] === particles_ref[end]
 
         # Resample and propagate particles.
-        AdvancedPS.resample_propagate!(Random.GLOBAL_RNG, pc)
+        AdvancedPS.resample_propagate!(Random.GLOBAL_RNG, pc, sampler)
         @test pc.logWs == zeros(3)
         @test AdvancedPS.getweights(pc) == fill(1 / 3, 3)
         @test all(AdvancedPS.getweight(pc, i) == 1 / 3 for i in 1:3)

--- a/test/pgas.jl
+++ b/test/pgas.jl
@@ -46,6 +46,7 @@
             AdvancedPS.Trace(BaseModel(Params(0.9, 0.31, 1)), AdvancedPS.TracedRNG()) for
             _ in 1:3
         ]
+        sampler = AdvancedPS.PGAS(3)
         resampler = AdvancedPS.ResampleWithESSThreshold(1.0)
 
         part = particles[3]
@@ -58,11 +59,11 @@
         pc = AdvancedPS.ParticleContainer(particles, AdvancedPS.TracedRNG(), base_rng)
 
         AdvancedPS.reweight!(pc, ref)
-        AdvancedPS.resample_propagate!(base_rng, pc, resampler, ref)
+        AdvancedPS.resample_propagate!(base_rng, pc, sampler, resampler, ref)
 
         AdvancedPS.reweight!(pc, ref)
         pc.logWs = [-Inf, 0, -Inf] # Force ancestor update to second particle
-        AdvancedPS.resample_propagate!(base_rng, pc, resampler, ref)
+        AdvancedPS.resample_propagate!(base_rng, pc, sampler, resampler, ref)
 
         AdvancedPS.reweight!(pc, ref)
         @test all(pc.vals[2].model.X[1:2] .≈ ref.model.X[1:2])


### PR DESCRIPTION
@yebai as discussed, `update_ref!(ref, pc)` should instead be something like this `update_ref!(ref, pc, sampler)` so that we can dispatch properly on the sampler type. 

With this, we can clean up the SSM example in the doc to remove all the `Libtask` references and just compare `PG` and `PGAS` on an `AbstractStateSpaceModel`