### PR TITLE
Make particle Gibbs deterministic across architectures

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AdvancedPS"
 uuid = "576499cb-2369-40b2-a588-c64705576edc"
 authors = ["TuringLang"]
-version = "0.6"
+version = "0.6.1"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/rng.jl
+++ b/src/rng.jl
@@ -36,8 +36,9 @@ Base.rand(rng::TracedRNG, ::Type{T}) where {T} = Base.rand(rng.rng, T)
 Split `key` into `n` new keys
 """
 function split(key::Integer, n::Integer=1)
-    T = typeof(key) # Make sure the type of `key` is consistent on W32 and W64 systems.
-    return T[hash(key, i) for i in UInt(1):UInt(n)]
+    T = typeof(key)
+    inner_rng = Random.MersenneTwister(key)
+    return rand(inner_rng, T, n)
 end
 
 """

--- a/test/linear-gaussian.jl
+++ b/test/linear-gaussian.jl
@@ -26,7 +26,7 @@ end
 @testset "linear-gaussian.jl" begin
     T = 3
     N_PARTICLES = 100
-    N_SAMPLES = 50
+    N_SAMPLES = 200
 
     # Model dynamics
     a = 0.5
@@ -100,12 +100,14 @@ end
     @testset "PGAS" begin
         pgas = AdvancedPS.PGAS(N_PARTICLES)
         p = test_algorithm(rng, pgas, model, N_SAMPLES, Xf)
+        @info p
         @test p > 0.05
     end
 
     @testset "PG" begin
         pg = AdvancedPS.PG(N_PARTICLES)
         p = test_algorithm(rng, pg, model, N_SAMPLES, Xf)
+        @info p
         @test p > 0.05
     end
 end


### PR DESCRIPTION
Fixes #108 

The problem was in this function `split`:

https://github.com/TuringLang/AdvancedPS.jl/blob/379336b8fcd662baa4a227100c94aefe491d62fe/src/rng.jl#L33-L41

Here, `UInt(1)` gives `UInt64` on 64-bit systems., and `UInt32` on 32-bit. Thus, the result of `hash` was different, despite ensuring that we convert back to the same type at the end.

The 'simple' solution of replacing `UInt` with `UInt64` doesn't work, because on 32-bit systems, `hash(::UInt64, ::UInt64)` is not defined.

This PR therefore uses a pseudo-random number generator to deterministically generate new values of type `T` from the original value.