### PR TITLE
Allow passing kwargs on to Libtask (when it's an `AbstractTuringLibtaskModel`...)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AdvancedPS"
 uuid = "576499cb-2369-40b2-a588-c64705576edc"
 authors = ["TuringLang"]
-version = "0.7.1"
+version = "0.7.2"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/ext/AdvancedPSLibtaskExt.jl
+++ b/ext/AdvancedPSLibtaskExt.jl
@@ -35,7 +35,32 @@ State wrapper to hold `Libtask.CTask` model initiated from `f`.
 function AdvancedPS.LibtaskModel(
     f::AdvancedPS.AbstractGenericModel, rng::Random.AbstractRNG, args...
 ) # Changed the API, need to take care of the RNG properly
-    return AdvancedPS.LibtaskModel(f, Libtask.TapedTask(TapedGlobals(rng), f, args...))
+    return AdvancedPS.LibtaskModel(
+        f, Libtask.TapedTask(TapedGlobals(rng), f, args...)
+    )
+end
+# TODO: Upstream this to Turing
+function AdvancedPS.LibtaskModel(
+    f::AdvancedPS.AbstractTuringLibtaskModel, rng::Random.AbstractRNG
+)
+    return AdvancedPS.LibtaskModel(
+        f, Libtask.TapedTask(TapedGlobals(rng), f.fargs...; f.kwargs...)
+    )
+end
+
+const LibtaskTrace{R} = AdvancedPS.Trace{<:AdvancedPS.LibtaskModel,R}
+
+function to_tapedtask(
+    newf::AdvancedPS.AbstractGenericModel, trace::LibtaskTrace, rng::Random.AbstractRNG
+)
+    return Libtask.TapedTask(TapedGlobals(rng, get_other_global(trace)), newf)
+end
+function to_tapedtask(
+    newf::AdvancedPS.AbstractTuringLibtaskModel, trace::LibtaskTrace, rng::Random.AbstractRNG
+)
+    return Libtask.TapedTask(
+        TapedGlobals(rng, get_other_global(trace)), newf.fargs...; newf.kwargs...
+    )
 end
 
 """
@@ -46,8 +71,6 @@ The task is copied (forked) and the inner model is deepcopied.
 function Base.copy(model::AdvancedPS.LibtaskModel)
     return AdvancedPS.LibtaskModel(deepcopy(model.f), copy(model.ctask))
 end
-
-const LibtaskTrace{R} = AdvancedPS.Trace{<:AdvancedPS.LibtaskModel,R}
 
 function Base.copy(trace::LibtaskTrace)
     newtrace = AdvancedPS.Trace(copy(trace.model), deepcopy(trace.rng))
@@ -114,7 +137,7 @@ function AdvancedPS.forkr(trace::LibtaskTrace)
     newf = AdvancedPS.reset_model(trace.model.f)
     Random123.set_counter!(rng, 1)
 
-    ctask = Libtask.TapedTask(TapedGlobals(rng, get_other_global(trace)), newf)
+    ctask = to_tapedtask(newf, trace, rng)
     new_tapedmodel = AdvancedPS.LibtaskModel(newf, ctask)
 
     # add backward reference

--- a/ext/AdvancedPSLibtaskExt.jl
+++ b/ext/AdvancedPSLibtaskExt.jl
@@ -35,9 +35,7 @@ State wrapper to hold `Libtask.CTask` model initiated from `f`.
 function AdvancedPS.LibtaskModel(
     f::AdvancedPS.AbstractGenericModel, rng::Random.AbstractRNG, args...
 ) # Changed the API, need to take care of the RNG properly
-    return AdvancedPS.LibtaskModel(
-        f, Libtask.TapedTask(TapedGlobals(rng), f, args...)
-    )
+    return AdvancedPS.LibtaskModel(f, Libtask.TapedTask(TapedGlobals(rng), f, args...))
 end
 # TODO: Upstream this to Turing
 function AdvancedPS.LibtaskModel(
@@ -56,7 +54,9 @@ function to_tapedtask(
     return Libtask.TapedTask(TapedGlobals(rng, get_other_global(trace)), newf)
 end
 function to_tapedtask(
-    newf::AdvancedPS.AbstractTuringLibtaskModel, trace::LibtaskTrace, rng::Random.AbstractRNG
+    newf::AdvancedPS.AbstractTuringLibtaskModel,
+    trace::LibtaskTrace,
+    rng::Random.AbstractRNG,
 )
     return Libtask.TapedTask(
         TapedGlobals(rng, get_other_global(trace)), newf.fargs...; newf.kwargs...

--- a/src/AdvancedPS.jl
+++ b/src/AdvancedPS.jl
@@ -16,6 +16,10 @@ abstract type AbstractParticleSampler <: AbstractMCMC.AbstractSampler end
 abstract type AbstractStateSpaceModel <: AbstractParticleModel end
 abstract type AbstractGenericModel <: AbstractParticleModel end
 
+# TODO(penelopeysm): This should be upstreamed to Turing together with anything that is
+# Turing-specific in LibtaskExt.
+abstract type AbstractTuringLibtaskModel <: AbstractGenericModel end
+
 include("resampling.jl")
 include("rng.jl")
 include("model.jl")


### PR DESCRIPTION
This PR modifies LibtaskExt to allow sampling from Turing models with keyword arguments with SMC or PG. See https://github.com/TuringLang/Turing.jl/pull/2660 for usage.

It's obviously quite ugly, the problem is that even though Turing is the only library that subtypes the abstract type, the abstract type has to be defined in AdvancedPS so that the LibtaskExt can dispatch on it. Ideally, that abstract type + any relevant methods inside LibtaskExt should just be shifted into Turing proper. That's for another time.