### PR TITLE
Add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      all-github-actions-packages:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "julia"
+    directories:
+      - "/"
+      - "/docs"
+      - "/examples/gaussian-process"
+      - "/examples/gaussian-ssm"
+      - "/examples/levy-ssm"
+      - "/examples/particle-gibbs"
+      - "/test"
+    schedule:
+      interval: "weekly"
+    groups:
+      all-julia-packages:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds `.github/dependabot.yml` to track GitHub Actions and Julia dependency updates weekly.